### PR TITLE
defer closing tmpfile

### DIFF
--- a/main.go
+++ b/main.go
@@ -182,7 +182,7 @@ func (o *OmnitruckProxy) proxy(req *http.Request) (*OmnitruckResponse, error) {
 			return nil, fmt.Errorf("Failed to open temporay file for reading: %s", err)
 		}
 		cacheUrl, err = o.Cache.Store(packageURL.EscapedPath(), tmpfile)
-		tmpfile.Close()
+		defer tmpfile.Close()
 
 		if err != nil {
 			return nil, fmt.Errorf("Failed to store %s in cache: %v ", omni.Url, err)


### PR DESCRIPTION
Fix file already closed

2019/03/20 16:04:01 Caching https://packages.chef.io/files/stable/chef/14.11.21/windows/2016/chef-client-14.11.21-1-x64.msi
2019/03/20 16:04:03 Downloaded and verified https://packages.chef.io/files/stable/chef/14.11.21/windows/2016/chef-client-14.11.21-1-x64.msi
2019/03/20 16:04:03 ERROR: Failed to store https://packages.chef.io/files/stable/chef/14.11.21/windows/2016/chef-client-14.11.21-1-x64.msi in cache: Put https://xxx.msi: read /tmp/chef896961112: file already closed